### PR TITLE
Fix README

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Properties | Description
 ### EPSignatureViewController Delegates
 ```swift
 func epSignature(_: EPSignature.EPSignatureViewController, didCancel error: NSError)
-func epSignature(_: EPSignature.EPSignatureViewController, didSigned signatureImage: UIImage, boundingRect: CGRect)
+func epSignature(_: EPSignature.EPSignatureViewController, didSign signatureImage: UIImage, boundingRect: CGRect)
 ```
 
 Note: boundingRect will contain the bounds of the signed image retrieved. Crop using this rect to make shorter and small signature images


### PR DESCRIPTION
Hi,

I got this error: `unrecognized selector sent to instance`,
this is because `onTouchDoneButton` calls `epSignature` with arg name `didSign`.

glad if no other developers misread and get that error.
