### PR TITLE
Update EPSignatureViewController.swift

### DIFF
--- a/Pod/Classes/EPSignatureViewController.swift
+++ b/Pod/Classes/EPSignatureViewController.swift
@@ -53,7 +53,7 @@ public class EPSignatureViewController: UIViewController {
             dateFormatter.dateFormat = "dd MMMM YYYY"
             lblDate.text = dateFormatter.stringFromDate(NSDate())
         } else {
-            lblDate.hidden = false
+            lblDate.hidden = true
         }
         
         if showsSaveSignatureOption {


### PR DESCRIPTION
Default date label text is displayed when passing in FALSE for showsDate.  
Changed lblDate.hidden to TRUE 
