### PR TITLE
Update lineWidth of bezierPath on strokeWidth change.

### DIFF
--- a/Pod/Classes/EPSignatureView.swift
+++ b/Pod/Classes/EPSignatureView.swift
@@ -21,7 +21,9 @@ open class EPSignatureView: UIView {
     // MARK: - Public Vars
     
     open var strokeColor = UIColor.black
-    open var strokeWidth: CGFloat = 2.0
+    open var strokeWidth: CGFloat = 2.0 {
+	    didSet { bezierPath.lineWidth = strokeWidth }
+    }
     open var isSigned: Bool = false
     
     // MARK: - Initializers


### PR DESCRIPTION
The current implementation does not allow changing the strokeWidth. The strokeWidth is used only once during initialization to set  the lineWidth of the bezierPath, this should also be done when a new strokeWidth is set.