### PR TITLE
Support to UI Rotation

### DIFF
--- a/Pod/Classes/EPSignatureView.swift
+++ b/Pod/Classes/EPSignatureView.swift
@@ -15,8 +15,6 @@ open class EPSignatureView: UIView {
     fileprivate var bezierPoints = [CGPoint](repeating: CGPoint(), count: 5)
     fileprivate var bezierPath = UIBezierPath()
     fileprivate var bezierCounter : Int = 0
-    fileprivate var maxPoint = CGPoint.zero
-    fileprivate var minPoint = CGPoint.zero
     
     // MARK: - Public Vars
     
@@ -31,7 +29,6 @@ open class EPSignatureView: UIView {
         self.backgroundColor = UIColor.clear
         bezierPath.lineWidth = strokeWidth
         addLongPressGesture()
-        minPoint = CGPoint(x: self.frame.size.width,y: self.frame.size.height)
     }
     
     public override init(frame: CGRect) {
@@ -39,7 +36,6 @@ open class EPSignatureView: UIView {
         self.backgroundColor = UIColor.clear
         bezierPath.lineWidth = strokeWidth
         addLongPressGesture()
-        minPoint = CGPoint(x: self.frame.size.width,y: self.frame.size.height)
     }
     
     override open func draw(_ rect: CGRect) {
@@ -61,7 +57,7 @@ open class EPSignatureView: UIView {
     
     func longPressed(_ gesture: UILongPressGestureRecognizer) {
         let touchPoint = gesture.location(in: self)
-        let endAngle = CGFloat(2.0 * M_PI)
+        let endAngle: CGFloat = .pi * 2.0
         bezierPath.move(to: touchPoint)
         bezierPath.addArc(withCenter: touchPoint, radius: 2, startAngle: 0, endAngle: endAngle, clockwise: true)
         setNeedsDisplay()
@@ -100,21 +96,7 @@ open class EPSignatureView: UIView {
     
     func touchPoint(_ touches: Set<UITouch>) -> CGPoint? {
         if let touch = touches.first {
-            let point = touch.location(in: self)
-            //Track the signature bounding area
-            if point.x > maxPoint.x {
-                maxPoint.x = point.x
-            }
-            if point.y > maxPoint.y {
-                maxPoint.y = point.y
-            }
-            if point.x < minPoint.x {
-                minPoint.x = point.x
-            }
-            if point.y < minPoint.y {
-                minPoint.y = point.y
-            }
-            return point
+            return touch.location(in: self)
         }
         return nil
     }
@@ -126,6 +108,16 @@ open class EPSignatureView: UIView {
     open func clear() {
         isSigned = false
         bezierPath.removeAllPoints()
+        setNeedsDisplay()
+    }
+    
+    /** scales and repositions the path
+     */
+    open func reposition() {
+        var ratio =  min(self.bounds.width / bezierPath.bounds.width, 1)
+        ratio =  min((self.bounds.height - 64) / bezierPath.bounds.height, ratio)
+        bezierPath.apply(CGAffineTransform(scaleX: ratio, y: ratio))
+        bezierPath.apply(CGAffineTransform(translationX: -bezierPath.bounds.origin.x, y: -bezierPath.bounds.origin.y + 64))
         setNeedsDisplay()
     }
     
@@ -146,7 +138,7 @@ open class EPSignatureView: UIView {
      */
 
     open func getSignatureBoundsInCanvas() -> CGRect {
-        return CGRect(x: minPoint.x, y: minPoint.y, width: maxPoint.x - minPoint.x, height: maxPoint.y - minPoint.y)
+        return bezierPath.bounds
     }
     
     //MARK: Save load signature methods

--- a/Pod/Classes/EPSignatureViewController.swift
+++ b/Pod/Classes/EPSignatureViewController.swift
@@ -145,4 +145,7 @@ open class EPSignatureViewController: UIViewController {
         signatureView.clear()
     }
     
+    override open func didRotate(from fromInterfaceOrientation: UIInterfaceOrientation) {
+        signatureView.reposition()
+    }
 }


### PR DESCRIPTION
ViewController listens to didRotate(from fromInterfaceOrientation: UIInterfaceOrientation) and tells View to reposition
View scales and repositions bezierPath to fit on screen
maxPoint & maxPoint replaced with bezierPath.bounds as they weren’t updated on rotate.