### PR TITLE
Improve quality of the signature image

### DIFF
--- a/Pod/Classes/EPSignatureView.swift
+++ b/Pod/Classes/EPSignatureView.swift
@@ -126,8 +126,8 @@ open class EPSignatureView: UIView {
      */
     open func getSignatureAsImage() -> UIImage? {
         if isSigned {
-            UIGraphicsBeginImageContext(CGSize(width: self.bounds.size.width, height: self.bounds.size.height))
-            self.layer.render(in: UIGraphicsGetCurrentContext()!)
+            UIGraphicsBeginImageContextWithOptions(bounds.size, false, 0)
+            drawHierarchy(in: bounds, afterScreenUpdates: false)
             let signature: UIImage = UIGraphicsGetImageFromCurrentImageContext()!
             UIGraphicsEndImageContext()
             return signature


### PR DESCRIPTION
Improves quality of the screenshot. Also uses `drawHierarchy` which is faster than `render`.

**Comparison:**
<img width="674" alt="signaturecomparison" src="https://user-images.githubusercontent.com/3887042/44061649-9f9dd140-9f59-11e8-9c2f-11f523a6947b.png">
