### PR TITLE
Update EPSignatureViewController designated initializer

### DIFF
--- a/Pod/Classes/EPSignatureViewController.swift
+++ b/Pod/Classes/EPSignatureViewController.swift
@@ -87,7 +87,7 @@ open class EPSignatureViewController: UIViewController {
         self.init(signatureDelegate: signatureDelegate, showsDate: showsDate, showsSaveSignatureOption: true)
     }
     
-    public init(signatureDelegate: EPSignatureDelegate, showsDate: Bool, showsSaveSignatureOption: Bool ) {
+    public init(signatureDelegate: EPSignatureDelegate?, showsDate: Bool, showsSaveSignatureOption: Bool ) {
         self.showsDate = showsDate
         self.showsSaveSignatureOption = showsSaveSignatureOption
         self.signatureDelegate = signatureDelegate


### PR DESCRIPTION
`signatureDelegate: EPSignatureDelegate?` is nil but we are forced to set a value in the `EPSignatureViewController`. I made it so we can pass nil for the delegate. 
This allows us to subclass `EPSignatureViewController` and set the delegate to self.